### PR TITLE
Add careers job search to CN whitelist

### DIFF
--- a/config.js
+++ b/config.js
@@ -23,6 +23,7 @@ var whitelist = [
   "//developers.google.com/groups",
   "//developers.google.com/events",
   "//firebase.google.com/support/contact/",
+  "//careers.google.com/jobs",
 ]
 
 function mirrorUrl(url) {


### PR DESCRIPTION
Job search function is not available on CN site, and is only available on international sites. This patch adds it to whitelist.