### PR TITLE
Add mapping for Google Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@
 | google.com/maps | google.cn/maps |
 | translate.google.com | translate.google.cn |
 | careers.google.com | careers.google.cn |
+| finance.google.com | caijing.google.cn |

--- a/config.js
+++ b/config.js
@@ -16,6 +16,7 @@ var mirrors = {
   "//developers.googleblog.com"       : "//developers.googleblog.cn",
   "//material.io"                     : "//md.gl",
   "//developerstudyjams.com"          : "//studyjamscn.com",
+  "//finance.google.com"              : "//caijing.google.cn",
 }
 
 // These URL paths are not available on CN mirrors, therefore won't be transformed.
@@ -24,6 +25,7 @@ var whitelist = [
   "//developers.google.com/events",
   "//firebase.google.com/support/contact/",
   "//careers.google.com/jobs",
+  "//finance.google.com/finance/portfolio",
 ]
 
 function mirrorUrl(url) {


### PR DESCRIPTION
caijing.google.cn appears to be working at present, even though finance.google.cn still hosts the China landing page.