### PR TITLE
Add mapping for golang.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 | developers.googleblog.com | developers.googleblog.cn |
 | material.io | md.gl |
 | developerstudyjams.com | studyjamscn.com |
+| golang.org | golang.google.cn |
 
 同时它还包含一些其他 Google 服务的网址映射：
 

--- a/config.js
+++ b/config.js
@@ -17,6 +17,7 @@ var mirrors = {
   "//material.io"                     : "//md.gl",
   "//developerstudyjams.com"          : "//studyjamscn.com",
   "//finance.google.com"              : "//caijing.google.cn",
+  "//golang.org"                      : "//golang.google.cn"
 }
 
 // These URL paths are not available on CN mirrors, therefore won't be transformed.

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,8 @@
     "*://*.code-labs.io/",
     "*://*.googleblog.com/",
     "*://*.material.io/",
-    "*://*.developerstudyjams.com/"
+    "*://*.developerstudyjams.com/",
+    "*://*.golang.org/"
   ],
   
   "background": {


### PR DESCRIPTION
The new golang.google.cn is released just now

(I9b8096d4f3ae4b7f9d26337e0e280fbe3ccf835c, https://go-review.googlesource.com/c/blog/+/86735)