### PR TITLE
Add mapping for some site and format the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 | 映射前网址 | 映射后网址 |
 | ------------- | ------------- |
-| developers.google.com  | developers.google.cn |
-| firebase.google.com  | firebase.google.cn |
+| developers.google.com | developers.google.cn |
+| firebase.google.com | firebase.google.cn |
 | developer.android.com | developer.android.google.cn |
 | source.android.com | source.android.google.cn |
 | www.tensorflow.org | tensorflow.google.cn |

--- a/config.js
+++ b/config.js
@@ -14,7 +14,6 @@ var mirrors = {
 
 // These URL paths are not available on CN mirrors, therefore won't be transformed.
 var whitelist = [
-  "//firebase.google.com/support/contact/",
   "//careers.google.com/jobs"
 ]
 

--- a/config.js
+++ b/config.js
@@ -8,15 +8,14 @@ var mirrors = {
   "//angular.io"                      : "//angular.cn",
   "//translate.google.com"            : "//translate.google.cn",
   "//careers.google.com"              : "//careers.google.cn",
-  "//golang.org"                      : "//golang.google.cn"
+  "//golang.org"                      : "//golang.google.cn",
+  "//sum.golang.org"                  : "//sum.golang.google.cn"
 }
 
 // These URL paths are not available on CN mirrors, therefore won't be transformed.
 var whitelist = [
-  "//developers.google.com/groups",
-  "//developers.google.com/events",
   "//firebase.google.com/support/contact/",
-  "//careers.google.com/jobs",
+  "//careers.google.com/jobs"
 ]
 
 function mirrorUrl(url) {


### PR DESCRIPTION
New CN mirrors:
| origin | mirror |
| --- | --- |
| [sum.golang.org](https://sum.golang.org/) | [sum.golang.google.cn](https://sum.golang.google.cn/) |
| [developers.google.com/groups](https://developers.google.com/groups/) | [developers.google.cn/groups](https://developers.google.cn/groups/) |
| [developers.google.com/events](https://developers.google.com/events/) | [developers.google.cn/events](https://developers.google.cn/events) |

`index` and `proxy` for `Golang` is not avaliable on CN mirrors, so the `mirror` of `sum.golang.org` is not even with the `origin`

three developer sites are removed from `whitelist`