### PR TITLE
fix: solve the async problem during the first load

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,12 @@ jobs:
     
     - name: package files
       run: |
-        zip -q "google-cn-devsites-extension_${{ steps.get-version.outputs.result }}.zip" bg.js manifest.json rules.json off.png on.png
+        zip -q "google_cn_devsites.zip" bg.js manifest.json rules.json off.png on.png
     
     - name: Create Release
       run: |
         gh release create ${{ steps.get-version.outputs.result }} -n "${{ env.MESSAGE }}" -t "${{ env.name }}" ${{ env.files }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        name: google-cn-devsites-extension_${{ steps.get-version.outputs.result }}
-        files: google-cn-devsites-extension_${{ steps.get-version.outputs.result }}.zip
+        name: google_cn_devsites-${{ steps.get-version.outputs.result }}
+        files: google_cn_devsites.zip

--- a/bg.js
+++ b/bg.js
@@ -21,15 +21,13 @@ function reset(currentState) {
   }
 }
 
-// Default to "on".
-chrome.storage.local.get(['currentState'], function (result) {
-  if (result.currentState === undefined) {
-    chrome.storage.local.set({ currentState: "on" })
-  }
-})
-
+// init state
 chrome.storage.local.get(['currentState'], result => {
-  reset(result.currentState);
+  if (result.currentState === undefined) {
+    result.currentState = "on"; // default to "on"
+    chrome.storage.local.set({ currentState: result.currentState });
+  }
+  reset(result.currentState); // reset state
 })
 
 chrome.action.onClicked.addListener(function (tab) {

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,6 @@
   
   "permissions": [
     "declarativeNetRequest",
-    "declarativeNetRequestFeedback",
     "storage"
   ],
   "declarative_net_request": {


### PR DESCRIPTION
Fixed the bug caused by async calls of `chrome.storage`: 

```
The state of the extension is inconsistent with the state in `chrome.storage` when the extension is loaded for first time.
```

Other changes:

```
1.Remove the required permission of `declarativeNetRequestFeedback`, this is not used at all.
2.Rename the CI file for release with some other changes.
```
