### PR TITLE
feat: add mapping for tfhub.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 | developer.android.com | developer.android.google.cn |
 | source.android.com | source.android.google.cn |
 | www.tensorflow.org | tensorflow.google.cn |
+| tfhub.dev | hub.tensorflow.google.cn |
 | angular.io | angular.cn |
 | golang.org | golang.google.cn |
 | sum.golang.org | sum.golang.google.cn |

--- a/config.js
+++ b/config.js
@@ -5,6 +5,7 @@ var mirrors = {
   "//developer.android.com"     : "developer.android.google.cn",
   "//source.android.com"        : "source.android.google.cn",
   "//www.tensorflow.org"        : "tensorflow.google.cn",
+  "//tfhub.dev"                 : "hub.tensorflow.google.cn",
   "//angular.io"                : "angular.cn",
   "//translate.google.com"      : "translate.google.cn",
   "//careers.google.com"        : "careers.google.cn",

--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,7 @@
     "*://*.google.com/*",
     "*://*.android.com/*",
     "*://*.tensorflow.org/*",
+    "*://*.tfhub.dev/*",
     "*://*.angular.io/*",
     "*://*.golang.org/*"
   ],


### PR DESCRIPTION
The CN mirror of [Tensorflow Hub](https://tfhub.dev/) is [hub.tensorflow.google.cn](https://hub.tensorflow.google.cn/). Adding it to mirror list.