### PR TITLE
fix: using `chrome.runtime.onStartup` listener to init the state

### DIFF
--- a/bg.js
+++ b/bg.js
@@ -9,31 +9,32 @@ function reset(currentState) {
 
     chrome.declarativeNetRequest.updateEnabledRulesets({
       "enableRulesetIds": ["ruleset_1"]
-    })
-  }
-  else {
+    });
+  } else {
     chrome.action.setIcon({ path: "off.png" });
     chrome.action.setTitle({ title: "Status: OFF" });
 
     chrome.declarativeNetRequest.updateEnabledRulesets({
       "disableRulesetIds": ["ruleset_1"]
-    })
+    });
   }
-  
+
   chrome.storage.local.set({ currentState: currentState });
 }
 
 // init state
-chrome.storage.local.get(['currentState'], result => {
-  if (result.currentState === undefined) {
-    result.currentState = "on"; // default to "on"
-  }
-  reset(result.currentState); // reset state
-})
+chrome.runtime.onStartup.addListener(() => {
+  chrome.storage.local.get("currentState", result => {
+    if (result.currentState === undefined) {
+      result.currentState = "on"; // default to "on"
+    }
+    reset(result.currentState); // reset state
+  });
+});
 
-chrome.action.onClicked.addListener(function (tab) {
-  chrome.storage.local.get(['currentState'], result => {
+chrome.action.onClicked.addListener(tab => {
+  chrome.storage.local.get("currentState", result => {
     const currentState = toggleState(result.currentState);
     reset(currentState);
-  })
+  });
 });

--- a/config.js
+++ b/config.js
@@ -11,18 +11,17 @@ var mirrors = {
   "//careers.google.com"        : "careers.google.cn",
   "//golang.org"                : "golang.google.cn",
   "//sum.golang.org"            : "sum.golang.google.cn"
-}
+};
 
 // These URL paths are not available on CN mirrors, therefore won't be transformed.
 var skiplist = [
   "//careers.google.com/jobs"
-]
+];
 
 function redirectRules() {
-  let res = []
-  let id = 1
-  for (var index in skiplist) {
-    var url = skiplist[index]
+  let res = [];
+  let id = 1;
+  for (const url of skiplist) {
     res.push({
       "id": id++,
       "action": {
@@ -33,9 +32,9 @@ function redirectRules() {
         "excludedResourceTypes": ["other"],
         "isUrlFilterCaseSensitive": false
       }
-    })
+    });
   }
-  for (let key in mirrors) {
+  for (const key in mirrors) {
     res.push({
       "id": id++,
       "action": {
@@ -51,18 +50,17 @@ function redirectRules() {
         "excludedResourceTypes": ["other"],
         "isUrlFilterCaseSensitive": false
       }
-    })
+    });
   }
-  return res
+  return res;
 }
 
 // Export rules to 'rules.json' (node.js is required)
-var fs = require('fs')
+const fs = require('fs');
 fs.writeFile('rules.json', JSON.stringify(redirectRules()), err => {
   if (err) {
-    console.error(err)
-	return
+    console.error(err);
   } else {
-    console.log('rules.json created.')
+    console.log('rules.json created.');
   }
-})
+});


### PR DESCRIPTION
- Using chrome.runtime.onStartup to init the state, the listener will be called when the broswer is starting.
    The service worker is working with events, using `startup` event listener is better(the script bellow won't be called when the browser is starting).
    https://github.com/chenzhuo914/google-cn-devsites-extension/blob/6e66fe8cc204ba298baf08777eeef062c1559c43/bg.js#L26-L32
    Using `startup` event listener to init state
    ````javascript
    // init state
    chrome.runtime.onStartup.addListener(() => {
      chrome.storage.local.get("currentState", result => {
        if (result.currentState === undefined) {
          result.currentState = "on"; // default to "on"
        }
        reset(result.currentState); // reset state
      });
    });
   ````
- Format the code.
  - using `for(value in array)` to traverse the value of array
  - add trailing semicolon