### PR TITLE
add `golang.org/issue` to skiplist

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,7 +15,8 @@ var mirrors = {
 
 // These URL paths are not available on CN mirrors, therefore won't be transformed.
 var skiplist = [
-  "//careers.google.com/jobs"
+  "//careers.google.com/jobs",
+  "//golang.org/issue"
 ];
 
 function redirectRules() {


### PR DESCRIPTION
[golang.org/issue](https://golang.org/issue) is not available in `CN mirrors`, adding it to skiplist.
