### PR TITLE
Update mapping for some sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 | www.tensorflow.org | tensorflow.google.cn |
 | tfhub.dev | hub.tensorflow.google.cn |
 | angular.io | angular.cn |
+| go.dev | golang.google.cn |
 | golang.org | golang.google.cn |
 | sum.golang.org | sum.golang.google.cn |
 

--- a/config.js
+++ b/config.js
@@ -9,14 +9,14 @@ var mirrors = {
   "//angular.io"                : "angular.cn",
   "//translate.google.com"      : "translate.google.cn",
   "//careers.google.com"        : "careers.google.cn",
+  "//go.dev"                    : "golang.google.cn",
   "//golang.org"                : "golang.google.cn",
   "//sum.golang.org"            : "sum.golang.google.cn"
 };
 
 // These URL paths are not available on CN mirrors, therefore won't be transformed.
 var skiplist = [
-  "//careers.google.com/jobs",
-  "//golang.org/issue"
+  "//careers.google.com/jobs"
 ];
 
 function redirectRules() {


### PR DESCRIPTION
Add:

- `go.dev`  ---> `golang.gooogle.cn`

Remove:

- `golang.org/issue` in skiplist

## why modify

For `go.dev` ---> `golang.gooogle.cn`, the blog in [`go.dev`](https://go.dev/blog/tidy-web) annonced that: "they will be merging the golang.org sites into a single coherent web" (date: `18 August 2021`). Now the merge has been done, and the request `https://golang.org` will be redirected to `https://go.dev` (the new site is the same as `https://golang.google.cn` now).

For removing `golang.org/issue` in skiplist, this URL is used for redirect to `https://github.com/golang/go/issues`, and this is now worked on `golang.google.cn`.

### curl test

```bash
curl https://golang.google.cn/issue/51752
# <a href="https://github.com/golang/go/issues/51752">Found</a>.
```