### PR TITLE
Add more Google CN resources

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,11 @@
     "*://*.tensorflow.org/*",
     "*://*.tfhub.dev/*",
     "*://*.angular.io/*",
-    "*://*.golang.org/*"
+    "*://*.golang.org/*",
+    "*://*.gstatic.com/*",
+    "*://*.googleapis.com/*",
+    "*://*.google.cn/*",
+    "*://*.gstatic.cn/*"
   ],
   
   "background": {


### PR DESCRIPTION
- Add more Google CN resources
- To make sure the replacement of static resources (and existing ones) works, ACAO headers are added.
- Some domains are commented out because they are still resolved to Google CN currently, but the replacement also works.